### PR TITLE
fixed the 'idDoesNotExist' error upon running `run_query_sync -c /hom…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,7 +36,7 @@
         "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
-            "source.organizeImports": true
+            "source.organizeImports": "explicit"
         },
     },
     "python.defaultInterpreterPath": "~/miniconda3/envs/evagg/bin/python",

--- a/lib/evagg/_library.py
+++ b/lib/evagg/_library.py
@@ -224,6 +224,9 @@ class PubMedFileLibrary(IGetPapers):
             error = root.find("error")
             if error.attrib["code"] == "idIsNotOpenAccess":  # type: ignore
                 return False
+            elif error.attrib["code"] == "idDoesNotExist":  # type: ignore
+                print(f"PMC ID {pmcid} does not exist.")
+                return False
             else:
                 raise NotImplementedError(f"Unexpected error code {error.attrib['code']}")  # type: ignore
         match = next(record for record in root.find("records") if record.attrib["id"] == pmcid)  # type: ignore


### PR DESCRIPTION
I added a couple of lines to fix this error:
```
(evagg) azureuser@evagg-ash-1:~/ev-agg-exp$ run_query_sync -c /home/azureuser/ev-agg-exp/lib/scripts/config/pubmed_library_config.yaml Traceback (most recent call last): File "/home/azureuser/miniconda3/envs/evagg/bin/run_query_sync", line 6, in sys.exit(main()) File "/home/azureuser/ev-agg-exp/lib/scripts/run_query_sync/_cli.py", line 21, in main app.execute() File "/home/azureuser/ev-agg-exp/lib/evagg/_app.py", line 19, in execute papers = self._library.search(self._query) File "/home/azureuser/ev-agg-exp/lib/evagg/_library.py", line 143, in search return self._build_papers(pmid_list) File "/home/azureuser/ev-agg-exp/lib/evagg/_library.py", line 241, in _build_papers is_pmc_oa = self._is_pmc_oa(pmcid) if pmcid is not None else False File "/home/azureuser/ev-agg-exp/lib/evagg/_library.py", line 228, in _is_pmc_oa raise NotImplementedError(f"Unexpected error code {error.attrib['code']}") # type: ignore NotImplementedError: Unexpected error code idDoesNotExist
```
and for example gene `TP53` the output shows

```
(evagg) azureuser@evagg-ash-1:~/ev-agg-exp$ run_query_sync -c /home/azureuser/ev-agg-exp/lib/scripts/config/pubmed_library_config.yaml
1  Citation:  Voskarides (2023) Cells, 10.3390/cells12030512
Found 1 papers for {TP53:R46C}
Found 2 variant mentions in 10.3390/cells12030512
Processing rs1042522
Processing rs1064796681
Writing output to: stdout
variant gene    paper_id        hgvsc   hgvsp   phenotype       zygosity        inheritance
rs1042522       TP53    10.3390/cells12030512   NM_000546.6:c.215C>T    NP_000537.3:p.Pro72Leu  ['increased risk of developing various types of cancer', 'decreased ability to repair damaged DNA', 'increased susceptibility to environmental carcinogens']      heterozygous    dominant
rs1064796681    TP53    10.3390/cells12030512   NM_000546.6:c.521G>T    NP_000537.3:p.Arg174Met ['increased risk of developing various types of cancer', 'early onset of cancer', 'poor response to chemotherapy']      heterozygous      autosomal dominant
```

illustrating a successful run. 