### PR TITLE
update aoai proxy config

### DIFF
--- a/run_aoai_proxy.sh
+++ b/run_aoai_proxy.sh
@@ -66,4 +66,4 @@ if [ ! -f "$FILE_PATH" ]; then
 fi
 
 # Run the proxy with the default HF pool configuration.
-"$FILE_PATH" -config-url="https://hflabgeneral.blob.core.windows.net/aoaiproxy/health-futures-default/services.yaml"
+"$FILE_PATH" -config-url="https://evaggsa.blob.core.windows.net/aoai-proxy/services-evagg.yaml"


### PR DESCRIPTION
Quick PR to use a aoai proxy config that is specific to the evagg pipeline's needs. In addition to merging in this PR, all users will need to update the `AZURE_OPENAI_DEPLOYMENT` key in their `.env` file to point to `gpt-4-1106-preview` instead of just `gpt-4`.