### PR TITLE
Import multiple AOAI endpoints

### DIFF
--- a/deploy/aoai.tf
+++ b/deploy/aoai.tf
@@ -1,17 +1,32 @@
-# TODO: hardcoded for now, should be parameterized and turned into a managed resource.
 data "azurerm_cognitive_account" "aoai_service" {
-  resource_group_name = "aoai-dev"
-  name                = "bmcaoai2"
+  for_each = var.aoai_deployments
+  resource_group_name = each.value
+  name                = each.key
 }
 
+locals {
+  # Make a list of all the authorized user/AOAI service pairs.
+  role_assignments = flatten([
+    for user in data.azuread_users.authorized_users.users : [
+      for service in data.azurerm_cognitive_account.aoai_service : {
+        user_id = user.object_id
+        service_id = service.id
+      }
+    ]
+  ])
+}
+
+# Add a role assignment for each authorized user for all the AOAI services.
 resource "azurerm_role_assignment" "aoai_service" {
-  for_each             = toset([for user in data.azuread_users.authorized_users.users : user.object_id])
-  scope                = data.azurerm_cognitive_account.aoai_service.id
+  for_each = {
+    for assignment in local.role_assignments : "${assignment.user_id}-${assignment.service_id}" => assignment
+  }
+  scope                = each.value.service_id
   role_definition_name = "Cognitive Services OpenAI User"
-  principal_id         = each.value
+  principal_id         = each.value.user_id
 }
 
-output "AZURE_OPENAI_ENDPOINT" {
-  description = "The endpoint for the AOAI chat service."
-  value       = data.azurerm_cognitive_account.aoai_service.endpoint
+output "AZURE_OPENAI_ENDPOINTS" {
+  description = "The endpoints for the AOAI chat services."
+  value       = [for service in data.azurerm_cognitive_account.aoai_service : service.endpoint]
 }

--- a/deploy/config.auto.tfvars.json
+++ b/deploy/config.auto.tfvars.json
@@ -7,5 +7,9 @@
         "Greg": "SC-gp287",
         "Miah": "SC-lt308",
         "Ashley": "SC-db243"
+    },
+    "aoai_deployments": {
+        "bmcaoai2": "aoai-dev",
+        "bmcaoai-swedencentral": "aoai-dev"
     }
 }

--- a/deploy/variables.tf
+++ b/deploy/variables.tf
@@ -31,3 +31,9 @@ variable "authorized_users" {
   type        = map(string)
   default     = {}
 }
+
+variable "aoai_deployments" {
+  description = "Map of cognitive service account name => resource group name."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
This pull request adds support for importing multiple AOAI endpoints. It introduces a new variable `aoai_deployments` which is a map of cognitive service account name to resource group name. The code changes ensure that role assignments are added for each authorized user for all the AOAI services. Additionally, the output variable `AZURE_OPENAI_ENDPOINTS` now returns a list of endpoints for the AOAI chat services.