### PR TITLE
Bar plots of weighted, raw, and coefficient NASA TLX by user by category with and without EvAgg

### DIFF
--- a/scripts/user_study/nasa_tlx_analysis.py
+++ b/scripts/user_study/nasa_tlx_analysis.py
@@ -648,7 +648,7 @@ def main(args: argparse.Namespace) -> None:
     create_combined_scatter_plots(without_copilot, with_copilot, nasa_categories, output_dir)
 
     # 6. Create and save 6x8 bar plots comparing NASA TLX weighted and raw scores and coefficients per category and user
-    # with and without Copilot
+    #    with and without Copilot
     for suffix in ["weighted_score", "raw", "coef"]:
         plot_nasa_tlx_per_category(without_copilot, with_copilot, nasa_categories, output_dir, suffix)
 


### PR DESCRIPTION
This is an addition to the `nasa_tlx_analysis.py` script to plot 3 bar plots of weighted, raw, and coefficient NASA TLX by user by category with and without the tool. The script now also has type hinting based on Miah's great recommendation! Both `mypy` and `flake8` linters are happy. 