### PR TITLE
Feature/truthset v1 1 bugfix

### DIFF
--- a/data/v1.1/README.md
+++ b/data/v1.1/README.md
@@ -1,0 +1,11 @@
+# V1.1 Truthset Exceptions
+
+During comparison of the v1 and v1.1 truthsets, it was observed that 2 papers in the train split that were not in
+PubMed's Open Access subset were subsequently moved over. Since these papers were not in PMC-OA at the time of pipeline
+execution for benchmarks, they were not processed, thus they have been manually set to `can_access = False` in the v1.1
+truthset. If for any reason this truthset is regenerated, then these papers must again be modified.
+
+The two papers in question are:
+
+37962692
+38114583

--- a/data/v1.1/papers_test_v1.1.tsv
+++ b/data/v1.1/papers_test_v1.1.tsv
@@ -7,6 +7,7 @@ PTCD3	30607703	True	False	unknown	test
 PRPH	15322088	True	False	unknown	test
 PRPH	15446584	True	False	not_open_access	test
 PRPH	20363051	True	False	unknown	test
+PRPH	25299611	True	True	CC BY	test
 PRPH	26742954	True	False	unknown	test
 PRPH	32638105	True	False	unknown	test
 PRPH	25588603	True	False	unknown	test
@@ -33,12 +34,13 @@ AHCY	35789945	True	False	CC BY-NC-ND	test
 AHCY	38052822	True	True	CC BY	test
 AHCY	15024124	True	False	not_open_access	test
 AHCY	16736098	True	False	not_open_access	test
+AHCY	27848944	True	True	CC BY	test
 AHCY	35463910	True	True	CC BY	test
 NLGN3	12669065	True	False	not_open_access	test
 NLGN3	24126926	True	False	unknown	test
 NLGN3	25167861	True	True	CC BY-NC	test
 NLGN3	25363768	True	False	not_open_access	test
-NLGN3	28841651	True	True	CC BY	test
+NLGN3	25533962	True	True	none	test
 NLGN3	28263302	True	False	not_open_access	test
 NLGN3	15150161	True	False	unknown	test
 NLGN3	19360662	True	False	not_open_access	test
@@ -94,6 +96,7 @@ NLGN3	33758193	True	True	CC BY	test
 NLGN3	36479216	True	True	CC BY	test
 NLGN3	37509099	True	True	CC BY	test
 NLGN3	38475840	True	True	CC BY	test
+NLGN3	28841651	True	True	CC BY	test
 FOXE3	26854927	True	False	not_open_access	test
 FOXE3	26995144	True	False	unknown	test
 FOXE3	27669367	True	False	unknown	test

--- a/data/v1.1/papers_train_v1.1.tsv
+++ b/data/v1.1/papers_train_v1.1.tsv
@@ -1,6 +1,7 @@
 gene	pmid	has_fulltext	can_access	license	group
 CTF1	11058912	True	False	unknown	train
 CTF1	24503780	True	False	unknown	train
+CTF1	26084686	True	True	CC BY-NC	train
 FBN2	9605585	True	False	unknown	train
 FBN2	9714438	True	False	unknown	train
 FBN2	9737771	True	False	unknown	train
@@ -106,9 +107,12 @@ SARS1	36041817	True	True	CC BY	train
 SARS1	34570399	True	False	unknown	train
 BAZ2B	31999386	True	False	not_open_access	train
 BAZ2B	25363768	True	False	not_open_access	train
+BAZ2B	28135719	True	True	none	train
+BAZ2B	28554332	True	True	CC BY	train
 BAZ2B	28867142	True	False	not_open_access	train
 BAZ2B	31398340	True	False	not_open_access	train
 BAZ2B	31981491	True	False	not_open_access	train
+BAZ2B	33057194	True	True	none	train
 BAZ2B	37872713	True	False	unknown	train
 TAPBP	12149238	True	False	unknown	train
 B4GAT1	34587870	True	False	unknown	train
@@ -219,9 +223,11 @@ JPH2	35238659	True	False	CC BY-NC-ND	train
 JPH2	36357925	True	True	CC BY	train
 JPH2	37371654	True	True	CC BY	train
 JPH2	29540472	True	False	unknown	train
+JPH2	29165669	True	True	none	train
 JPH2	35800456	True	True	CC BY-NC	train
 JPH2	38438248	True	True	CC BY	train
 GRXCR2	24619944	True	False	not_open_access	train
+GRXCR2	28383030	True	True	CC BY	train
 GRXCR2	32048449	True	True	CC BY	train
 GRXCR2	30157177	True	True	CC0	train
 GRXCR2	33528103	True	True	CC BY	train

--- a/data/v1.1/papers_train_v1.1.tsv
+++ b/data/v1.1/papers_train_v1.1.tsv
@@ -64,9 +64,9 @@ FBN2	36800380	True	True	CC BY	train
 FBN2	36849876	True	False	CC BY-NC-ND	train
 FBN2	36936417	True	True	CC BY	train
 FBN2	37399314	True	False	unknown	train
-FBN2	37962692	True	True	CC BY	train
+FBN2	37962692	True	False	CC BY	train
 FBN2	38099230	True	True	CC BY	train
-FBN2	38114583	True	True	CC BY	train
+FBN2	38114583	True	False	CC BY	train
 FBN2	38215673	True	False	unknown	train
 FBN2	38326314	True	True	CC BY	train
 FBN2	37100863	True	True	CC BY	train

--- a/scripts/benchmark/content_extraction/manuscript_generate_content_figures.py
+++ b/scripts/benchmark/content_extraction/manuscript_generate_content_figures.py
@@ -83,6 +83,50 @@ for run_type in ["train", "test"]:
         item.set_rotation(90)
 
 
+# %% Make another version of the plot where train and test are shown together.
+
+sns.set_theme(style="whitegrid")
+
+all_obs_run_stats_labeled = []
+for run_type in ["train", "test"]:
+    run_stats_labeled = all_obs_run_stats[run_type].copy()
+    run_stats_labeled["split"] = run_type
+    all_obs_run_stats_labeled.append(run_stats_labeled)
+
+obs_run_stats_labeled = pd.concat(all_obs_run_stats_labeled)
+
+obs_run_stats_labeled_melted = obs_run_stats_labeled[
+    [
+        "split",
+        "run_id",
+        "zygosity",
+        "variant_type",
+        "variant_inheritance",
+        "phenotype",
+        "study_type",
+        "animal_model",
+        "engineered_cells",
+        "patient_cells_tissues",
+    ]
+].melt(id_vars=["split", "run_id"], var_name="metric", value_name="result")
+
+plt.figure()
+
+g = sns.barplot(
+    data=obs_run_stats_labeled_melted,
+    x="metric",
+    y="result",
+    errorbar="sd",
+    hue="split",
+    alpha=0.6,
+)
+g.xaxis.set_label_text("")
+g.yaxis.set_label_text("Accuracy")
+g.set_xticklabels(g.get_xticklabels(), rotation=90)
+
+g.title.set_text("Content extraction benchmark results")
+plt.ylim(0.25, 1)
+
 # %% Print them instead.
 
 max_columns = pd.get_option("display.max_columns")

--- a/scripts/benchmark/content_extraction/manuscript_generate_obs_figures.py
+++ b/scripts/benchmark/content_extraction/manuscript_generate_obs_figures.py
@@ -155,10 +155,13 @@ g = sns.barplot(
     hue="split",
     alpha=0.6,
 )
+# rename the x labels to precision, recall, precision (variant), recall (variant).
+g.set_xticklabels(["Precision", "Recall", "Precision (var)", "Recall (var)"])
+
 g.xaxis.set_label_text("")
-g.yaxis.set_label_text("Performance")
+g.yaxis.set_label_text("Performance metric")
 g.title.set_text(f"Observation finding benchmark results{model_suffix}")
-plt.ylim(0, 1)
+plt.ylim(0.5, 1)
 
 # %% Print them instead.
 

--- a/scripts/benchmark/content_extraction/manuscript_obs_model_comparison.py
+++ b/scripts/benchmark/content_extraction/manuscript_obs_model_comparison.py
@@ -11,6 +11,8 @@ from typing import Dict
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
+from statsmodels.stats.anova import AnovaRM
+from statsmodels.stats.multicomp import MultiComparison
 
 # %% Constants.
 
@@ -54,6 +56,41 @@ for metric in ["precision", "recall"]:
         plt.title(f"Observation finding {metric} [{split}]")
         plt.ylim(0, 1)
 
+# Make a bar plot that combines train and test into a single plot
+for metric in ["recall", "recall_variant"]:
+    plt.figure(figsize=(6, 6))
+    sns.barplot(
+        data=data,
+        x="model",
+        y=metric,
+        errorbar="sd",
+        hue="split",
+    )
+    plt.title(f"Model comparison - Observation finding {metric}")
+    plt.ylim(0, 1)
+
+# %% Detailed stats.
+
+for metric in ["recall", "recall_variant"]:
+    fit_data = data[[metric, "model", "split"]].copy()
+    fit_data.reset_index(names="subject", inplace=True)
+
+    # Impute to handle class balancing issues.
+    fit_data.loc[len(fit_data)] = {"subject": 4, metric: None, "model": "GPT-4o", "split": "test"}
+
+    fit_data[metric] = fit_data.groupby(["model", "split"])[metric].transform(lambda x: x.fillna(x.mean()))
+
+    aovrm = AnovaRM(fit_data, metric, "subject", within=["model", "split"])
+    res = aovrm.fit()
+
+    # Print the results
+    print(res)
+
+    # Since model is significant, we can do a post-hoc comparison using Tukey's HSD test.
+
+    mc = MultiComparison(fit_data[metric], fit_data["model"])
+    result = mc.tukeyhsd()
+    print(result)
 
 # %% Print out summary statistics.
 

--- a/scripts/benchmark/content_extraction/manuscript_obs_model_comparison.py
+++ b/scripts/benchmark/content_extraction/manuscript_obs_model_comparison.py
@@ -55,4 +55,21 @@ for metric in ["precision", "recall"]:
         plt.ylim(0, 1)
 
 
+# %% Print out summary statistics.
+
+# Make a table that averages across runs, stratified on model and split, giving average precision and recall for each.
+summary = (
+    data.groupby(["model", "split"])[["precision", "recall", "precision_variant", "recall_variant"]]
+    .agg(["mean", "std"])
+    .reset_index()
+)
+
+# Just display to 3 sig figs
+summary = summary.round(3)
+
+# Don't let pandas split rows over newlines.
+pd.set_option("display.expand_frame_repr", False)
+print(summary)
+
+
 # %% Intentionally empty.

--- a/scripts/benchmark/paper_finding/manuscript_generate_figures.py
+++ b/scripts/benchmark/paper_finding/manuscript_generate_figures.py
@@ -155,7 +155,7 @@ g.xaxis.set_label_text("")
 g.yaxis.set_label_text("Performance metric")
 g.title.set_text(f"Paper finding benchmark results{model_name}")
 
-plt.ylim(0.6, 1)
+plt.ylim(0.5, 1)
 
 # %% Print them instead.
 

--- a/scripts/benchmark/paper_finding/manuscript_generate_figures.py
+++ b/scripts/benchmark/paper_finding/manuscript_generate_figures.py
@@ -155,7 +155,7 @@ g.xaxis.set_label_text("")
 g.yaxis.set_label_text("Performance metric")
 g.title.set_text(f"Paper finding benchmark results{model_name}")
 
-plt.ylim(0, 1)
+plt.ylim(0.6, 1)
 
 # %% Print them instead.
 
@@ -164,10 +164,14 @@ for run_type in ["train", "test"]:
 
     print(f"-- Paper finding benchmark results ({run_type}; N={run_stats.shape[0]}) --")
 
-    print(run_stats[["n_correct", "n_missed", "n_irrelevant", "precision", "recall", "f1"]])
+    print(run_stats[["n_correct", "n_missed", "n_irrelevant", "precision", "recall", "f1"]].round(3))
 
     print()
-    print(run_stats[["n_correct", "n_missed", "n_irrelevant", "precision", "recall", "f1"]].aggregate(["mean", "std"]))
+    print(
+        run_stats[["n_correct", "n_missed", "n_irrelevant", "precision", "recall", "f1"]]
+        .aggregate(["mean", "std"])
+        .round(3)
+    )
     print()
 
 

--- a/scripts/benchmark/paper_finding/manuscript_model_comparison.py
+++ b/scripts/benchmark/paper_finding/manuscript_model_comparison.py
@@ -52,4 +52,13 @@ for metric in ["precision", "recall"]:
         plt.ylim(0, 1)
 
 
+# %% Print out summary statistics.
+
+# Make a table that averages across runs, stratified on model and split, giving average precision and recall for each.
+summary = data.groupby(["model", "split"])[["precision", "recall"]].agg(["mean", "std"]).reset_index()
+
+# Just display to 3 sig figs
+summary = summary.round(3)
+print(summary)
+
 # %% Intentionally empty.

--- a/scripts/benchmark/paper_finding/manuscript_model_comparison.py
+++ b/scripts/benchmark/paper_finding/manuscript_model_comparison.py
@@ -6,6 +6,7 @@ in the `MODELS` constant below.
 
 # %% Imports.
 
+import json
 from typing import Dict
 
 import matplotlib.pyplot as plt
@@ -35,10 +36,27 @@ for model in MODELS:
 # Concatenate the dataframes.
 data = pd.concat([data_dicts[model][split] for model in MODELS for split in ["train", "test"]])
 
+# %% Incorporate runtimes and cost estimates.
+
+INVALID_RUNTIME_IDS = ["20240911_223218", "20240920_223702"]
+
+
+def get_runtime_sec(run_id: str) -> float:
+
+    metadata = json.load(open(f".out/run_evagg_pipeline_{run_id}/run.json"))
+    return metadata["elapsed_secs"]
+
+
+data["runtime"] = data.run_id.apply(get_runtime_sec)
+
+# Set the runtimes for the invalid runs to NaN.
+data.loc[data.run_id.isin(INVALID_RUNTIME_IDS), "runtime"] = None
+
+
 # %% Make plots.
 
 # Make a bar plot for precision on the test set where there is a different bar for each model, and std dev error bars.
-for metric in ["precision", "recall"]:
+for metric in ["precision", "recall", "f1"]:
     for split in ["train", "test"]:
         plt.figure(figsize=(6, 6))
         sns.barplot(
@@ -55,10 +73,11 @@ for metric in ["precision", "recall"]:
 # %% Print out summary statistics.
 
 # Make a table that averages across runs, stratified on model and split, giving average precision and recall for each.
-summary = data.groupby(["model", "split"])[["precision", "recall"]].agg(["mean", "std"]).reset_index()
+summary = data.groupby(["model", "split"])[["precision", "recall", "runtime"]].agg(["mean", "std"]).reset_index()
 
 # Just display to 3 sig figs
 summary = summary.round(3)
 print(summary)
+
 
 # %% Intentionally empty.

--- a/scripts/benchmark/paper_finding/manuscript_model_comparison.py
+++ b/scripts/benchmark/paper_finding/manuscript_model_comparison.py
@@ -12,6 +12,8 @@ from typing import Dict
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
+from statsmodels.stats.anova import AnovaRM
+from statsmodels.stats.multicomp import MultiComparison
 
 # %% Constants.
 
@@ -56,7 +58,7 @@ data.loc[data.run_id.isin(INVALID_RUNTIME_IDS), "runtime"] = None
 # %% Make plots.
 
 # Make a bar plot for precision on the test set where there is a different bar for each model, and std dev error bars.
-for metric in ["precision", "recall", "f1"]:
+for metric in ["precision", "recall"]:
     for split in ["train", "test"]:
         plt.figure(figsize=(6, 6))
         sns.barplot(
@@ -68,6 +70,40 @@ for metric in ["precision", "recall", "f1"]:
         )
         plt.title(f"Paper finding {metric} [{split}]")
         plt.ylim(0, 1)
+
+# Make a bar plot that combines train and test into a single plot
+for metric in ["precision", "recall"]:
+    plt.figure(figsize=(6, 6))
+    sns.barplot(
+        data=data,
+        x="model",
+        y=metric,
+        errorbar="sd",
+        hue="split",
+    )
+    plt.title(f"Model comparison - Paper finding {metric}")
+    plt.ylim(0.6, 1)
+
+# %% Detailed stats.
+
+# Test for a statistical effect of model using a 2-way anova with repeated measures
+# The factors are model and split, the dependent variable is recall.
+
+
+fit_data = data[["recall", "model", "split"]].copy()
+fit_data.reset_index(names="subject", inplace=True)
+
+aovrm = AnovaRM(fit_data, "recall", "subject", within=["model", "split"])
+res = aovrm.fit()
+
+# Print the results
+print(res)
+
+# Since model is significant, we can do a post-hoc comparison using Tukey's HSD test.
+
+mc = MultiComparison(fit_data["recall"], fit_data["model"])
+result = mc.tukeyhsd()
+print(result)
 
 
 # %% Print out summary statistics.

--- a/scripts/truthset/error_analysis/update_v1_truthset.py
+++ b/scripts/truthset/error_analysis/update_v1_truthset.py
@@ -38,6 +38,10 @@ ANALYST_RESPONSES_FILES = [
 # disagreements during error analysis.
 CONSENSUS_RESOLUTION_FILE = "data/error_analysis/resolved_discrepancies.tsv"
 
+# List of manually skipped PMIDs from the benchmarking process. Even if the error resolution process indicated that
+# these PMIDs should be removed from the truthset, they shouldn't be removed if they're on this list.
+SKIPPED_PMIDS = "scripts/benchmark/paper_finding/paper_finding_benchmarks_skipped_pmids.txt"
+
 # The original v1 truthset. This will serve as a starting point for the updated truthset.
 TRUTHSET_ROOT = "data/v1"
 
@@ -190,6 +194,9 @@ group_assignments = pd.read_csv(f"{TRUTHSET_ROOT}/group_assignments.tsv", sep="\
 
 discrepancies["group"] = discrepancies["gene"].map(group_assignments.set_index("gene")["group"])
 
+with open(SKIPPED_PMIDS) as f:
+    skipped_pmids = [int(line.strip()) for line in f.readlines()]
+
 # %% List the todos for papers, order by gene and group
 
 print("#")
@@ -198,6 +205,7 @@ print("#")
 print("")
 
 paper_discrepancies = discrepancies.query("task == 'papers'")
+paper_discrepancies = paper_discrepancies.query("pmid not in @skipped_pmids")
 
 for group, group_df in paper_discrepancies.groupby("group"):
     for gene, gene_df in group_df.groupby("gene"):

--- a/scripts/truthset/generate_manual_truth_set.py
+++ b/scripts/truthset/generate_manual_truth_set.py
@@ -28,7 +28,7 @@ from lib.di import DiContainer
 
 # %% Constants.
 
-TRUTH_XLSX = "./.tmp/Manual Ground Truth v1.1 - 2024.11.26.xlsx"
+TRUTH_XLSX = "./.tmp/Manual Ground Truth v1.1 - 2024.12.03.xlsx"
 GROUP_ASSIGNMENT_CSV = "./data/v1/group_assignments.tsv"
 TRUTHSET_VERSION = "v1.1"
 OUTPUT_ROOT = f"./data/{TRUTHSET_VERSION}"

--- a/scripts/truthset/truthset_version_comparison.py
+++ b/scripts/truthset/truthset_version_comparison.py
@@ -1,0 +1,84 @@
+"""This script is used to explore the differences between two versions of the truthset. This is useful for debugging,
+though we may not need to keep it around long-term."""
+
+# %% imports.
+
+import pandas as pd
+
+# %% data loading.
+
+group = "train"
+
+v1 = pd.read_csv(f"data/v1/papers_{group}_v1.tsv", sep="\t").set_index("pmid")
+v2 = pd.read_csv(f"data/v1.1/papers_{group}_v1.1.tsv", sep="\t").set_index("pmid")
+
+# read all the lines in from scripts/benchmark/paper_finding/paper_finding_benchmarks_skipped_pmids.txt as a list of
+# strings.
+
+with open("scripts/benchmark/paper_finding/paper_finding_benchmarks_skipped_pmids.txt") as f:
+    skipped_pmids = [int(line.strip()) for line in f.readlines()]
+
+# %% data comparison
+
+# show rows where the pmid exists in only one dataframe.
+v1_only = v1[~v1.index.isin(v2.index)]
+v2_only = v2[~v2.index.isin(v1.index)]
+
+# join the two dataframes and select rows where the values are different.
+joined = v1.join(v2, lsuffix="_v1", rsuffix="_v2", how="inner")
+diff = joined[
+    (joined["has_fulltext_v1"] != joined["has_fulltext_v2"])
+    | (joined["can_access_v1"] != joined["can_access_v2"])
+    | (joined["license_v1"] != joined["license_v2"])
+]
+
+# %% look at skipped pmids
+
+# list the pmids from v1_only and v2_only that are in skipped_pmids
+v1_skipped = v1_only[v1_only.index.isin(skipped_pmids)]
+v2_skipped = v2_only[v2_only.index.isin(skipped_pmids)]
+
+
+# %% print out all the results for easy comparison.
+
+print(f"V1 (N={v1.shape[0]})")
+print(f"V2 (N={v2.shape[0]})")
+print("\n\n")
+
+print(f"PAPERS IN V1 ONLY (N={v1_only.shape[0]}): ")
+print(v1_only)
+print("\n\n")
+
+print(f"PAPERS IN V2 ONLY (N={v2_only.shape[0]}): ")
+print(v2_only)
+print("\n\n")
+
+print(f"DIFFERENCES BETWEEN V1 AND V2 (N={diff.shape[0]}): ")
+print(diff)
+print("\n\n")
+
+print(f"PAPERS IN V1 THAT WERE SKIPPED (N={v1_skipped.shape[0]}): ")
+print(v1_skipped)
+print("\n\n")
+
+print(f"PAPERS IN V2 THAT WERE SKIPPED (N={v2_skipped.shape[0]}): ")
+print(v2_skipped)
+print("\n\n")
+
+# Show the math.
+v2_only_n = v2_only.shape[0]
+v1_only_n = v1_only.shape[0]
+
+v2_skipped_n = v2_skipped.shape[0]
+v1_skipped_n = v1_skipped.shape[0]
+
+print(
+    f"New papers for {group}: "
+    f"{v2_only_n} (v2 only) - {v1_only_n} (v1 only) + "
+    f"{diff.query('can_access_v2 == True').shape[0]} (changed to accessible) + "
+    f"{v1_skipped_n} (v1 skipped) - {v2_skipped_n} (v2 skipped) = "
+    f"{v2_only_n - v1_only_n + diff.query('can_access_v2 == True').shape[0] + v1_skipped_n - v2_skipped_n}"
+)
+
+
+# %% Intentionally empty.


### PR DESCRIPTION
This was originally intended to be a quick bugfix to the v1.1 truthset and grew into a larger PR that contains numerous updates to benchmark and analysis scripts to facilitate generation of stats and figures for the paper.

- v1.1 truth set bug - Somehow (likely my fault), the discrepancy resolution questions included asking the analysts whether the 12 papers identified in `scripts/benchmark/paper_finding/paper_finding_benchmarks_skipped_pmids.txt` were actually relevant. We'd been excluding these papers from all benchmarks because they aren't returned by pubmed searches for the query genes (the curators picked them up from ClinGen) so it didn't make sense to include them in benchmark analyses. Correspondingly, it didn't really make sense to include them in discrepancy resolution, and removing some of them from the v1.1 truth set gummed up the works. So the solution was to pretend we never asked the curators about them, leave them in the v1.1 truth set, and continue removing them from all downstream analyses at runtime. There are a handful of changes in this PR to that effect.
- sleuthing this out required me to write a script to compare the truthset's paper lists (`truthset_version_comparison.py`)
- substantial updates to various benchmark and analysis scripts to generate the specific sets of stats and figure outputs that are currently being used in the paper. Most notably the script `mgt_table_stats.py` was refactored into a notebook to facilitate paper writing.