### PR TITLE
Feature/error agreements

### DIFF
--- a/scripts/benchmark/content_extraction/batch_content_extraction.sh
+++ b/scripts/benchmark/content_extraction/batch_content_extraction.sh
@@ -11,11 +11,12 @@ populate_arrays() {
 
 # Check if model parameter is provided
 if [ -z "$1" ]; then
-    echo "Usage: $0 <model>"
+    echo "Usage: $0 <model> [truthset_version]"
     exit 1
 fi
 
 MODEL=$1
+TRUTHSET_VERSION=${2:-v1.1}
 JSON_FILE="scripts/benchmark/benchmark_runs.json"
 
 # Populate TRAIN and TEST arrays
@@ -25,12 +26,12 @@ populate_arrays "$MODEL" "$JSON_FILE"
 for run_id in "${TRAIN[@]}"; do
     echo "### Processing TRAIN run $run_id ###"
     python scripts/benchmark/content_extraction/manuscript_obs_content_single_run.py \
-    -m data/v1.1/evidence_train_v1.1.tsv -p "$run_id"
+    -m data/$TRUTHSET_VERSION/evidence_train_$TRUTHSET_VERSION.tsv -p "$run_id"
 done
 
 # Loop through each element in the TEST list
 for run_id in "${TEST[@]}"; do
     echo "### Processing TEST run $run_id ###"
     python scripts/benchmark/content_extraction/manuscript_obs_content_single_run.py \
-    -m data/v1.1/evidence_test_v1.1.tsv -p "$run_id"
+    -m data/$TRUTHSET_VERSION/evidence_test_$TRUTHSET_VERSION.tsv -p "$run_id"
 done

--- a/scripts/benchmark/content_extraction/manuscript_content_discrepancy_list.py
+++ b/scripts/benchmark/content_extraction/manuscript_content_discrepancy_list.py
@@ -46,6 +46,19 @@ def get_row_key(row: pd.Series, col: str) -> Tuple:
     return tuple(row[INDICES_FOR_COLUMN[col]])
 
 
+# There's a lot of book-keeping happening below to keep track of agreements and disagreements for content extraction.
+# The complexity arises because every run doesn't necessarily contain the same set of papers, nor the same set of
+# observations extracted from those papers. For the most part, these things are consistent, but it's possible that
+# if five runs are executed, the number of times a specific observation is found could be less. In order to ask the
+# follow up question as to whether agreement or disagreement was _consistent_ for any particular content value, we
+# also need to know how many opportunities we've had to even observe that fact. Therefore, we coun't the number of times
+# pipeline output for a particular content column was in agreement with the truth set AND the number of opportunies
+# we had to observe that fact.
+#
+# There is additional complexity about the phenotype column, because instead of being a discrete value, it's a set of
+# zero or more HPO terms (both in the truth data and pipeline outputs) and we're generalizing the terms to organ/system
+# level terms. This approach is outlined in more detail in the inline comments below.
+
 dicts: Dict[str, Dict[Tuple[Any, ...], Dict[str, Any]]] = {col: {} for col in CONTENT_COLUMNS}
 
 for run_type, run_ids in [("train", TRAIN_RUNS), ("test", TEST_RUNS)]:

--- a/scripts/benchmark/content_extraction/manuscript_content_discrepancy_list.py
+++ b/scripts/benchmark/content_extraction/manuscript_content_discrepancy_list.py
@@ -52,8 +52,6 @@ for run_type, run_ids in [("train", TRAIN_RUNS), ("test", TEST_RUNS)]:
     runs = [load_run(id, "content_extraction_results.tsv") for id in run_ids]
 
     for run in runs:
-        # if broken:
-        #     break
         if run is None:
             continue
 

--- a/scripts/benchmark/content_extraction/manuscript_content_discrepancy_list.py
+++ b/scripts/benchmark/content_extraction/manuscript_content_discrepancy_list.py
@@ -162,6 +162,16 @@ df["output_discrepancy_count"] = df.apply(
     axis=1,
 )
 
+# Next count the number of truth discrepancies. The approach here is analogous.
+df["truth_discrepancy_count"] = df.apply(
+    lambda row: sum(
+        len(set(row["truth_dict"][k]))
+        for k in row["truth_dict"]
+        if ((row["truth_count"][k] >= row["total_count"] / 2) & (row["total_count"] >= 2))
+    ),
+    axis=1,
+)
+
 # %% Write the dataframes to a CSV file.
 if not os.path.exists(OUTPUT_DIR):
     os.makedirs(OUTPUT_DIR)

--- a/scripts/benchmark/content_extraction/manuscript_obs_discrepancy_list.py
+++ b/scripts/benchmark/content_extraction/manuscript_obs_discrepancy_list.py
@@ -99,8 +99,13 @@ sns.histplot(data=var, x="discrepancy_count", bins=range(0, 11), discrete=True)
 sns.lineplot(x=[MIN_RECURRENCE - 0.5, MIN_RECURRENCE - 0.5], y=[0, 100], color="red", linestyle="--")
 
 
+# Print the number of discrepancies
 print(f"Found {obs['discrepancy'].sum()} observation discrepancies.")
 print(f"Found {var['discrepancy'].sum()} variant discrepancies.")
+
+# Print the number of agreements
+print(f"Found {(~obs['discrepancy']).sum()} observation agreements.")
+print(f"Found {(~var['discrepancy']).sum()} variant agreements.")
 
 # %% Write the dataframe to a CSV file.
 if not os.path.exists(OUTPUT_DIR):

--- a/scripts/benchmark/paper_finding/batch_paper_finding.sh
+++ b/scripts/benchmark/paper_finding/batch_paper_finding.sh
@@ -11,11 +11,12 @@ populate_arrays() {
 
 # Check if model parameter is provided
 if [ -z "$1" ]; then
-    echo "Usage: $0 <model>"
+    echo "Usage: $0 <model> [truthset_version]"
     exit 1
 fi
 
 MODEL=$1
+TRUTHSET_VERSION=${2:-v1.1}
 JSON_FILE="scripts/benchmark/benchmark_runs.json"
 
 # Populate TRAIN and TEST arrays
@@ -26,7 +27,7 @@ for run_id in "${TRAIN[@]}"; do
     echo "### Processing TRAIN run $run_id ###"
     python scripts/benchmark/paper_finding/manuscript_single_run.py \
     -s "scripts/benchmark/paper_finding/paper_finding_benchmarks_skipped_pmids.txt" \
-    -m data/v1.1/papers_train_v1.1.tsv -p "$run_id"
+    -m "data/$TRUTHSET_VERSION/papers_train_$TRUTHSET_VERSION.tsv" -p "$run_id"
 done
 
 # Loop through each element in the TEST list
@@ -34,5 +35,5 @@ for run_id in "${TEST[@]}"; do
     echo "### Processing TEST run $run_id ###"
     python scripts/benchmark/paper_finding/manuscript_single_run.py \
     -s "scripts/benchmark/paper_finding/paper_finding_benchmarks_skipped_pmids.txt" \
-    -m data/v1.1/papers_test_v1.1.tsv -p "$run_id"
+    -m "data/$TRUTHSET_VERSION/papers_test_$TRUTHSET_VERSION.tsv" -p "$run_id"
 done

--- a/scripts/benchmark/paper_finding/manuscript_discrepancy_list.py
+++ b/scripts/benchmark/paper_finding/manuscript_discrepancy_list.py
@@ -61,6 +61,7 @@ papers = pd.DataFrame(papers_dict).T
 # Each row in the dataframe where truth_count is not equal to pipeline_count is a discrepancy.
 papers["discrepancy"] = abs(papers["truth_count"] - papers["pipeline_count"]) >= MIN_RECURRENCE
 print(f"Found {papers['discrepancy'].sum()} discrepancies.")
+print(f"Found {(~papers['discrepancy']).sum()} agreements.")
 
 # %% Write the dataframe to a CSV file.
 if not os.path.exists(OUTPUT_DIR):


### PR DESCRIPTION
Changes to facilitate counting the number of consistent "agreements" and "disagreements" across benchmark runs.
- modification of single run benchmark scripts to accept truth set version [v1, v1.1] as a parameter
- modifications to benchmark analysis scripts to output agreement/disagreement counts

Tests pass and linters are happy 