### PR TITLE
Feature/repro updates

### DIFF
--- a/scripts/benchmark/README.md
+++ b/scripts/benchmark/README.md
@@ -30,8 +30,8 @@ lines above. By default, the outputs for these analyses will be placed in new, r
 
 2. **Figure generation**: In an interactive window (figures aren't currently written to disk), run
 `scripts/benchmark/paper_finding/manuscript_generate_figures.py`,
-`scripts/benchmark/content_extraction/manuscript_generate_figures.py`, and
-`scripts/benchmark/content_extraction/content_benchmark.py`. These will generate a bunch of figures that can be used in
+`scripts/benchmark/content_extraction/manuscript_generate_obs_figures.py`, and
+`scripts/benchmark/content_extraction/manuscript_generate_content_figures.py`. These will generate a bunch of figures that can be used in
 paper authoring. The first two scripts and will also generate a number of output TSVs that can be used in downstream
 analyses.
 

--- a/scripts/benchmark/README.md
+++ b/scripts/benchmark/README.md
@@ -11,44 +11,69 @@ From the appropriate cloud storage location, localize the benchmark run outputs 
 
 **Note: all of the steps below assume your working directory is `<REPO_ROOT>`.
 
-1. **Individual run analyses**: This entails running `paper_finding/manuscript_single_run.py` and
-`content_extraction/manuscript_obs_content_single_run.py` for every single output file localized. For the 30 runs
-specified in `benchmark_runs.json` this could get a little tedious, so we've provided a shell script that will run
-the above python scripts for all of the runs for a given model. These can be run as follows:
+
+1. **Individual run analyses (multi-truthset support)**: 
+   - The batch scripts (`batch_paper_finding.sh` and `batch_content_extraction.sh`) accept one or more truthset versions as additional arguments (default: `v1 v1.1`).
+   - The scripts will process all specified truthset versions, passing the version to downstream scripts and preventing output overwrites by suffixing output files with the truthset version.
+   - Example usage (processes both v1 and v1.1 by default):
 
     ```bash
     scripts/benchmark/content_extraction/batch_content_extraction.sh GPT-4-Turbo
     scripts/benchmark/paper_finding/batch_paper_finding.sh GPT-4-Turbo
-    scripts/benchmark/content_extraction/batch_content_extraction.sh GPT-4o
-    scripts/benchmark/paper_finding/batch_paper_finding.sh GPT-4o
-    scripts/benchmark/content_extraction/batch_content_extraction.sh GPT-4o-mini
-    scripts/benchmark/paper_finding/batch_paper_finding.sh GPT-4o-mini
+    # To specify a single version:
+    scripts/benchmark/content_extraction/batch_content_extraction.sh GPT-4-Turbo v1
+    scripts/benchmark/paper_finding/batch_paper_finding.sh GPT-4-Turbo v1.1
+    # To specify multiple versions explicitly:
+    scripts/benchmark/content_extraction/batch_content_extraction.sh GPT-4-Turbo v1 v1.1
+    scripts/benchmark/paper_finding/batch_paper_finding.sh GPT-4-Turbo v1 v1.1
     ```
 
-    If you are not planning on regenerating the model comparison outputs, then it is only necessary to run the first two
-lines above. By default, the outputs for these analyses will be placed in new, run-specific output folders in `.out`.
+   - The single-run analysis scripts (`manuscript_single_run.py` and `manuscript_obs_content_single_run.py`) now require a `--truthset-version` argument. All output files (not directories) will be suffixed with the specified truthset version.
+   - Example usage:
 
-2. **Figure generation**: In an interactive window (figures aren't currently written to disk), run
-`scripts/benchmark/paper_finding/manuscript_generate_figures.py`,
-`scripts/benchmark/content_extraction/manuscript_generate_obs_figures.py`, and
-`scripts/benchmark/content_extraction/manuscript_generate_content_figures.py`. These will generate a bunch of figures that can be used in
-paper authoring. The first two scripts and will also generate a number of output TSVs that can be used in downstream
-analyses.
+    ```bash
+    python scripts/benchmark/paper_finding/manuscript_single_run.py --truthset-version v1 ...
+    python scripts/benchmark/content_extraction/manuscript_obs_content_single_run.py --truthset-version v1.1 ...
+    ```
+
+   - By default, outputs are placed in new, run-specific output folders in `.out`, with filenames indicating the truthset version.
+
+
+2. **Figure generation (multi-truthset support)**: 
+   - The figure generation scripts (except phenotype figures) now aggregate and plot results for all specified truthset versions, grouping bars by truthset version in the main barplots.
+   - Run the following scripts in an interactive window or as python scripts (in this case outputs will be generated in new folders in the `.out/` directory):
+
+    ```bash
+    python scripts/benchmark/paper_finding/manuscript_generate_figures.py
+    python scripts/benchmark/content_extraction/manuscript_generate_obs_figures.py
+    python scripts/benchmark/content_extraction/manuscript_generate_content_figures.py
+    ```
+
+   - The first two scripts will also generate output TSVs for each truthset version, suffixed accordingly, for downstream analyses.
+   - The main barplots will display grouped bars by truthset version for easy comparison.
+
 
 3. **Discrepancy finding**: In an interactive window or as a python script, run
-`scripts/benchmark/paper_finding/manuscript_discrepancy_list.py`,
-`scripts/benchmark/content_extraction/manuscript_obs_discrepancy_list.py`, and
-`scripts/benchmark/content_extraction/manuscript_content_discrepancy_list.py`. These scripts will generate TSVs that
-will be used downstream in the generation of discrepancy questions. By default these TVS will be written to
-`.out/manuscript_paper_finding` and `.out/manuscript_content_extraction`
+   - `scripts/benchmark/paper_finding/manuscript_discrepancy_list.py`,
+   - `scripts/benchmark/content_extraction/manuscript_obs_discrepancy_list.py`, and
+   - `scripts/benchmark/content_extraction/manuscript_content_discrepancy_list.py`.
+   These scripts will generate TSVs for each truthset version (if applicable), written to `.out/manuscript_paper_finding` and `.out/manuscript_content_extraction`.
 
 4. **Discrepancy question generation**: In an interactive window or as a python script, run
 `scripts/benchmark/consolidate_discrepancy_questions.py`. This script will generate discrepancy questions and write out
 a set of files that organize those questions by pmid for faster manual review. By default these output files will be
 written to `.out/manuscript_content_extraction`.
 
+
 5. **Model comparison**: In an interactive window (figures aren't currently written to disk), run
-`scripts/benchmark/paper_finding/manuscript_model_comparison.py` and
-`scripts/benchmark/content_extraction/manuscript_obs_model_comparison.py` to generate figures comparing various AOAI 
-GPT models. Note: to run these notebooks you will need to have performed step 1 above for the pipeline outputs for
-GPT-4o and GPT4o-mini, not just GPT-4-Turbo.
+   - `scripts/benchmark/paper_finding/manuscript_model_comparison.py` and
+   - `scripts/benchmark/content_extraction/manuscript_obs_model_comparison.py`
+   to generate figures comparing various AOAI GPT models. Note: to run these notebooks you will need to have performed step 1 above for the pipeline outputs for all relevant truthset versions and models.
+
+---
+
+**Summary of multi-truthset-version workflow:**
+- Batch scripts accept one or more truthset versions as arguments and process all specified versions.
+- Single-run scripts require a `--truthset-version` argument and suffix output files with the version.
+- Figure scripts (except phenotype figures) aggregate and plot results for all specified truthset versions, grouping bars by version.
+- Output files and tables are version-suffixed to prevent overwrites and enable easy comparison.

--- a/scripts/benchmark/content_extraction/batch_content_extraction.sh
+++ b/scripts/benchmark/content_extraction/batch_content_extraction.sh
@@ -11,27 +11,36 @@ populate_arrays() {
 
 # Check if model parameter is provided
 if [ -z "$1" ]; then
-    echo "Usage: $0 <model> [truthset_version]"
+    echo "Usage: $0 <model> [truthset_version ...]"
     exit 1
 fi
 
 MODEL=$1
-TRUTHSET_VERSION=${2:-v1.1}
+shift
+TRUTHSET_VERSIONS=("$@")
+if [ ${#TRUTHSET_VERSIONS[@]} -eq 0 ]; then
+    TRUTHSET_VERSIONS=(v1 v1.1)
+fi
 JSON_FILE="scripts/benchmark/benchmark_runs.json"
 
-# Populate TRAIN and TEST arrays
-populate_arrays "$MODEL" "$JSON_FILE"
+for TRUTHSET_VERSION in "${TRUTHSET_VERSIONS[@]}"; do
+    echo "Processing for truthset version: $TRUTHSET_VERSION"
+    # Populate TRAIN and TEST arrays
+    populate_arrays "$MODEL" "$JSON_FILE"
 
-# Loop through each element in the TRAIN list
-for run_id in "${TRAIN[@]}"; do
-    echo "### Processing TRAIN run $run_id ###"
-    python scripts/benchmark/content_extraction/manuscript_obs_content_single_run.py \
-    -m data/$TRUTHSET_VERSION/evidence_train_$TRUTHSET_VERSION.tsv -p "$run_id"
-done
+    # Loop through each element in the TRAIN list
+    for run_id in "${TRAIN[@]}"; do
+        echo "### Processing TRAIN run $run_id for $TRUTHSET_VERSION ###"
+        python scripts/benchmark/content_extraction/manuscript_obs_content_single_run.py \
+        -m data/$TRUTHSET_VERSION/evidence_train_$TRUTHSET_VERSION.tsv -p "$run_id" \
+        --truthset-version "$TRUTHSET_VERSION"
+    done
 
-# Loop through each element in the TEST list
-for run_id in "${TEST[@]}"; do
-    echo "### Processing TEST run $run_id ###"
-    python scripts/benchmark/content_extraction/manuscript_obs_content_single_run.py \
-    -m data/$TRUTHSET_VERSION/evidence_test_$TRUTHSET_VERSION.tsv -p "$run_id"
+    # Loop through each element in the TEST list
+    for run_id in "${TEST[@]}"; do
+        echo "### Processing TEST run $run_id for $TRUTHSET_VERSION ###"
+        python scripts/benchmark/content_extraction/manuscript_obs_content_single_run.py \
+        -m data/$TRUTHSET_VERSION/evidence_test_$TRUTHSET_VERSION.tsv -p "$run_id" \
+        --truthset-version "$TRUTHSET_VERSION"
+    done
 done

--- a/scripts/benchmark/content_extraction/manuscript_generate_content_figures.py
+++ b/scripts/benchmark/content_extraction/manuscript_generate_content_figures.py
@@ -88,17 +88,22 @@ obs_run_stats_labeled_melted = obs_run_stats_labeled[
         "split",
         "truthset_version",
         "run_id",
-        "zygosity",
-        "variant_type",
-        "variant_inheritance",
         "phenotype",
+        "variant_inheritance",
+        "variant_type",
+        "zygosity",
     ]
 ].melt(id_vars=["split", "run_id", "truthset_version"], var_name="metric", value_name="result")
 
 # Recode split from "train" and "test" to "dev" and "eval".
 obs_run_stats_labeled_melted["split"] = obs_run_stats_labeled_melted["split"].map({"train": "dev", "test": "eval"})
 
-plt.figure(figsize=(4, 3))
+# Recode truthset_version from "v1" and "v1.1" to "Original dataset" and "Refined dataset".
+obs_run_stats_labeled_melted["truthset_version"] = obs_run_stats_labeled_melted["truthset_version"].map(
+    {"v1": "Original dataset", "v1.1": "Refined dataset"}
+)
+
+plt.figure(figsize=(6, 3))
 
 # Plot the eval data only.
 g = sns.barplot(
@@ -107,15 +112,18 @@ g = sns.barplot(
     y="result",
     errorbar="sd",
     hue="truthset_version",
-    alpha=0.6,
-    palette={"v1": "#1F77B4", "v1.1": "#FCA178"},
+    palette={"Original dataset": "#1F77B4", "Refined dataset": "#FCA178"},
 )
 g.xaxis.set_label_text("")
 g.yaxis.set_label_text("Accuracy")
 g.set_xticklabels(g.get_xticklabels())
 
-# Remove the legend.
-g.get_legend().remove()
+# Remove the legend title
+g.get_legend().set_title("")
+
+# Set legend location to lower right
+g.get_legend().set_loc("lower right")
+
 
 g.title.set_text("Content extraction")
 plt.ylim(0.4, 1)

--- a/scripts/benchmark/content_extraction/manuscript_generate_content_figures.py
+++ b/scripts/benchmark/content_extraction/manuscript_generate_content_figures.py
@@ -108,7 +108,7 @@ g = sns.barplot(
     errorbar="sd",
     hue="truthset_version",
     alpha=0.6,
-    palette={"v1": "#1F77B4", "v1.1": "#FA621E"},
+    palette={"v1": "#1F77B4", "v1.1": "#FCA178"},
 )
 g.xaxis.set_label_text("")
 g.yaxis.set_label_text("Accuracy")

--- a/scripts/benchmark/content_extraction/manuscript_generate_content_figures.py
+++ b/scripts/benchmark/content_extraction/manuscript_generate_content_figures.py
@@ -2,6 +2,7 @@
 
 # %% Imports.
 
+import os
 from typing import Any, Dict, List
 
 import pandas as pd
@@ -14,12 +15,15 @@ from scripts.benchmark.utils import CONTENT_COLUMNS, get_benchmark_run_ids, get_
 
 OUTPUT_DIR = ".out/manuscript_content_extraction"
 
+# ensure OUTPUT_DIR exists
+if not os.path.exists(OUTPUT_DIR):
+    os.makedirs(OUTPUT_DIR)
+
 LOCAL_CONTENT_COLUMNS = CONTENT_COLUMNS.copy()
 LOCAL_CONTENT_COLUMNS.remove("study_type")
 LOCAL_CONTENT_COLUMNS.remove("animal_model")
 LOCAL_CONTENT_COLUMNS.remove("engineered_cells")
 LOCAL_CONTENT_COLUMNS.remove("patient_cells_tissues")
-LOCAL_CONTENT_COLUMNS.remove("phenotype")
 
 TRAIN_RUNS = get_benchmark_run_ids("GPT-4-Turbo", "train")
 TEST_RUNS = get_benchmark_run_ids("GPT-4-Turbo", "test")
@@ -83,6 +87,7 @@ obs_run_stats_labeled_melted = obs_run_stats_labeled[
         "zygosity",
         "variant_type",
         "variant_inheritance",
+        "phenotype",
     ]
 ].melt(id_vars=["split", "run_id"], var_name="metric", value_name="result")
 

--- a/scripts/benchmark/content_extraction/manuscript_generate_content_figures.py
+++ b/scripts/benchmark/content_extraction/manuscript_generate_content_figures.py
@@ -28,68 +28,72 @@ LOCAL_CONTENT_COLUMNS.remove("patient_cells_tissues")
 TRAIN_RUNS = get_benchmark_run_ids("GPT-4-Turbo", "train")
 TEST_RUNS = get_benchmark_run_ids("GPT-4-Turbo", "test")
 
+TRUTHSET_VERSIONS = ["v1", "v1.1"]
+
 # %% Generate run stats for content extraction.
 
 all_obs_run_stats: Dict[str, pd.DataFrame] = {}
+all_obs_run_stats_labeled: List[pd.DataFrame] = []
 
-for run_type, run_ids in [("train", TRAIN_RUNS), ("test", TEST_RUNS)]:
+for truthset_version in TRUTHSET_VERSIONS:
+    for run_type, run_ids in [("train", TRAIN_RUNS), ("test", TEST_RUNS)]:
 
-    runs = [load_run(id, "content_extraction", "content_extraction_results.tsv") for id in run_ids]
+        runs = [
+            load_run(id, "content_extraction", f"content_extraction_results_{truthset_version}.tsv") for id in run_ids
+        ]
 
-    obs_run_stats_dicts: List[Dict[str, Any]] = []
+        obs_run_stats_dicts: List[Dict[str, Any]] = []
 
-    for run_id, run in zip(run_ids, runs):
-        if run is None:
-            continue
+        for run_id, run in zip(run_ids, runs):
+            if run is None:
+                continue
 
-        run.set_index(["gene", "pmid", "hgvs_desc", "individual_id"], inplace=True)
+            run.set_index(["gene", "pmid", "hgvs_desc", "individual_id"], inplace=True)
 
-        run_dict: Dict[str, Any] = {
-            "run_id": run_id,
-        }
+            run_dict: Dict[str, Any] = {
+                "run_id": run_id,
+            }
 
-        for column in LOCAL_CONTENT_COLUMNS:
+            for column in LOCAL_CONTENT_COLUMNS:
 
-            eval_df = get_eval_df(run, column)
+                eval_df = get_eval_df(run, column)
 
-            if column == "phenotype":
-                result_tuples = eval_df.phenotype_result.apply(eval)
-                result = sum(len(t[2]) == 0 and len(t[3]) == 0 for t in result_tuples) / len(result_tuples)
-            else:
-                result = eval_df[f"{column}_result"].mean()
+                if column == "phenotype":
+                    result_tuples = eval_df.phenotype_result.apply(eval)
+                    result = sum(len(t[2]) == 0 and len(t[3]) == 0 for t in result_tuples) / len(result_tuples)
+                else:
+                    result = eval_df[f"{column}_result"].mean()
 
-            run_dict[f"{column}_n"] = eval_df.shape[0]
-            run_dict[column] = result
+                run_dict[f"{column}_n"] = eval_df.shape[0]
+                run_dict[column] = result
 
-        obs_run_stats_dicts.append(run_dict)
+            run_dict["truthset_version"] = truthset_version
+            run_dict["split"] = run_type
 
-    run_stats = pd.DataFrame(obs_run_stats_dicts)
+            obs_run_stats_dicts.append(run_dict)
 
-    all_obs_run_stats[run_type] = run_stats
+        run_stats = pd.DataFrame(obs_run_stats_dicts)
+
+        all_obs_run_stats_labeled.append(run_stats)
 
 
 # %% Make another version of the plot where train and test are shown together.
 
 sns.set_theme(style="whitegrid")
 
-all_obs_run_stats_labeled = []
-for run_type in ["train", "test"]:
-    run_stats_labeled = all_obs_run_stats[run_type].copy()
-    run_stats_labeled["split"] = run_type
-    all_obs_run_stats_labeled.append(run_stats_labeled)
-
 obs_run_stats_labeled = pd.concat(all_obs_run_stats_labeled)
 
 obs_run_stats_labeled_melted = obs_run_stats_labeled[
     [
         "split",
+        "truthset_version",
         "run_id",
         "zygosity",
         "variant_type",
         "variant_inheritance",
         "phenotype",
     ]
-].melt(id_vars=["split", "run_id"], var_name="metric", value_name="result")
+].melt(id_vars=["split", "run_id", "truthset_version"], var_name="metric", value_name="result")
 
 # Recode split from "train" and "test" to "dev" and "eval".
 obs_run_stats_labeled_melted["split"] = obs_run_stats_labeled_melted["split"].map({"train": "dev", "test": "eval"})
@@ -102,9 +106,9 @@ g = sns.barplot(
     x="metric",
     y="result",
     errorbar="sd",
-    hue="split",
+    hue="truthset_version",
     alpha=0.6,
-    palette={"dev": "#1F77B4", "eval": "#FA621E"},
+    palette={"v1": "#1F77B4", "v1.1": "#FA621E"},
 )
 g.xaxis.set_label_text("")
 g.yaxis.set_label_text("Accuracy")
@@ -114,7 +118,7 @@ g.set_xticklabels(g.get_xticklabels())
 g.get_legend().remove()
 
 g.title.set_text("Content extraction")
-plt.ylim(0.5, 1)
+plt.ylim(0.4, 1)
 
 
 # Replace all the underscores in the xticklabels with spaces.
@@ -135,18 +139,19 @@ pd.set_option("display.max_columns", None)
 width = pd.get_option("display.width")
 pd.set_option("display.width", 2000)
 
-for run_type in ["train", "test"]:
-    run_stats = all_obs_run_stats[run_type]
+for truthset_version in TRUTHSET_VERSIONS:
+    for run_type in ["train", "test"]:
+        run_stats = obs_run_stats_labeled.query(f"truthset_version == '{truthset_version}' and split == '{run_type}'")
 
-    run_type_alt = "dev" if run_type == "train" else "eval"
+        run_type_alt = "dev" if run_type == "train" else "eval"
 
-    print(f"-- Content extraction benchmark results ({run_type_alt}; N={run_stats.shape[0]}) --")
+        print(f"-- Content extraction benchmark results ({run_type_alt}/{truthset_version}; N={run_stats.shape[0]}) --")
 
-    print(run_stats[["run_id"] + LOCAL_CONTENT_COLUMNS])
+        print(run_stats[["run_id"] + LOCAL_CONTENT_COLUMNS])
 
-    print()
-    print(run_stats[LOCAL_CONTENT_COLUMNS].aggregate(["mean", "std"]))
-    print()
+        print()
+        print(run_stats[LOCAL_CONTENT_COLUMNS].aggregate(["mean", "std"]))
+        print()
 
 pd.set_option("display.max_columns", max_columns)
 pd.set_option("display.width", width)

--- a/scripts/benchmark/content_extraction/manuscript_generate_obs_figures.py
+++ b/scripts/benchmark/content_extraction/manuscript_generate_obs_figures.py
@@ -22,6 +22,10 @@ from scripts.benchmark.utils import get_benchmark_run_ids, load_run
 
 OUTPUT_DIR = ".out/manuscript_content_extraction"
 
+# ensure OUTPUT_DIR exists
+if not os.path.exists(OUTPUT_DIR):
+    os.makedirs(OUTPUT_DIR)
+    
 MODEL = "GPT-4-Turbo"  # or "GPT-4o" or "GPT-4o-mini"
 
 TRAIN_RUNS = get_benchmark_run_ids(MODEL, "train")

--- a/scripts/benchmark/content_extraction/manuscript_generate_obs_figures.py
+++ b/scripts/benchmark/content_extraction/manuscript_generate_obs_figures.py
@@ -119,7 +119,6 @@ g = sns.barplot(
     y="result",
     errorbar="sd",
     hue="truthset_version",
-    alpha=0.6,
     palette={"v1": "#1F77B4", "v1.1": "#FCA178"},
 )
 # Rename the x labels to precision, recall, precision (variant), recall (variant).

--- a/scripts/benchmark/content_extraction/manuscript_generate_obs_figures.py
+++ b/scripts/benchmark/content_extraction/manuscript_generate_obs_figures.py
@@ -120,7 +120,7 @@ g = sns.barplot(
     errorbar="sd",
     hue="truthset_version",
     alpha=0.6,
-    palette={"v1": "#1F77B4", "v1.1": "#FA621E"},
+    palette={"v1": "#1F77B4", "v1.1": "#FCA178"},
 )
 # Rename the x labels to precision, recall, precision (variant), recall (variant).
 g.set_xticklabels(["Precision", "Recall", "Variant\nprecision", "Variant\nrecall"])
@@ -128,6 +128,8 @@ g.set_xticklabels(["Precision", "Recall", "Variant\nprecision", "Variant\nrecall
 g.xaxis.set_label_text("")
 g.yaxis.set_label_text("Proportion")
 g.title.set_text("Observation finding")
+g.get_legend().remove()
+
 plt.ylim(0.4, 1)
 
 plt.savefig(f"{OUTPUT_DIR}/observation_finding_performance{model_suffix}.png", bbox_inches="tight")

--- a/scripts/benchmark/content_extraction/manuscript_generate_obs_figures.py
+++ b/scripts/benchmark/content_extraction/manuscript_generate_obs_figures.py
@@ -25,7 +25,7 @@ OUTPUT_DIR = ".out/manuscript_content_extraction"
 # ensure OUTPUT_DIR exists
 if not os.path.exists(OUTPUT_DIR):
     os.makedirs(OUTPUT_DIR)
-    
+
 MODEL = "GPT-4-Turbo"  # or "GPT-4o" or "GPT-4o-mini"
 
 TRAIN_RUNS = get_benchmark_run_ids(MODEL, "train")
@@ -33,77 +33,79 @@ TEST_RUNS = get_benchmark_run_ids(MODEL, "test")
 
 model_suffix = f" - {MODEL}"
 
+TRUTHSET_VERSIONS = ["v1", "v1.1"]
+
 # %% Generate run stats for observation finding.
 
-all_obs_run_stats: Dict[str, pd.DataFrame] = {}
+all_obs_run_stats_labeled: List[pd.DataFrame] = []
 
-for run_type, run_ids in [("train", TRAIN_RUNS), ("test", TEST_RUNS)]:
+for truthset_version in TRUTHSET_VERSIONS:
+    for run_type, run_ids in [("train", TRAIN_RUNS), ("test", TEST_RUNS)]:
 
-    runs = [load_run(id, "content_extraction", "observation_finding_results.tsv") for id in run_ids]
+        runs = [
+            load_run(id, "content_extraction", f"observation_finding_results_{truthset_version}.tsv") for id in run_ids
+        ]
 
-    obs_run_stats_dicts: List[Dict[str, Any]] = []
+        obs_run_stats_dicts: List[Dict[str, Any]] = []
 
-    for run_id, run in zip(run_ids, runs):
-        if run is None:
-            continue
+        for run_id, run in zip(run_ids, runs):
+            if run is None:
+                continue
 
-        if run_id == "20240920_074218":
-            # This is a known busted run, skip it.
-            # More specifically, there was a AOAI generation failure in this run where the limit on output tokens
-            # was exceeded. Penalizing the corresponding model for this would be unfair.
-            continue
+            if run_id == "20240920_074218":
+                # This is a known busted run, skip it.
+                # More specifically, there was a AOAI generation failure in this run where the limit on output tokens
+                # was exceeded. Penalizing the corresponding model for this would be unfair.
+                continue
 
-        precision = run.in_truth[run.in_pipeline].mean()
-        recall = run.in_pipeline[run.in_truth].mean()
-        n = run.shape[0]
+            precision = run.in_truth[run.in_pipeline].mean()
+            recall = run.in_pipeline[run.in_truth].mean()
+            n = run.shape[0]
 
-        # Count the variant as being present in truth or pipeline output if it's present in any row, regardless of the
-        # individual_id for that row.
-        for _, grp_df in run.groupby(["pmid", "hgvs_desc"]):
-            if grp_df.in_truth.any():
-                run.loc[grp_df.index, "in_truth"] = True
-            if grp_df.in_pipeline.any():
-                run.loc[grp_df.index, "in_pipeline"] = True
+            # Count the variant as being present in truth or pipeline output if it's present in any row, regardless of
+            # the individual_id for that row.
+            for _, grp_df in run.groupby(["pmid", "hgvs_desc"]):
+                if grp_df.in_truth.any():
+                    run.loc[grp_df.index, "in_truth"] = True
+                if grp_df.in_pipeline.any():
+                    run.loc[grp_df.index, "in_pipeline"] = True
 
-        run.drop_duplicates(subset=["pmid", "hgvs_desc"], inplace=True, keep="first")
+            run.drop_duplicates(subset=["pmid", "hgvs_desc"], inplace=True, keep="first")
 
-        precision_variant = run.in_truth[run.in_pipeline].mean()
-        recall_variant = run.in_pipeline[run.in_truth].mean()
-        n_variant = run.shape[0]
+            precision_variant = run.in_truth[run.in_pipeline].mean()
+            recall_variant = run.in_pipeline[run.in_truth].mean()
+            n_variant = run.shape[0]
 
-        obs_run_stats_dicts.append(
-            {
-                "run_id": run_id,
-                "n": n,
-                "precision": precision,
-                "recall": recall,
-                "f1": 2 * precision * recall / (precision + recall),
-                "n_variant": n_variant,
-                "precision_variant": precision_variant,
-                "recall_variant": recall_variant,
-                "f1_variant": 2 * precision_variant * recall_variant / (precision_variant + recall_variant),
-            }
-        )
+            obs_run_stats_dicts.append(
+                {
+                    "run_id": run_id,
+                    "n": n,
+                    "precision": precision,
+                    "recall": recall,
+                    "f1": 2 * precision * recall / (precision + recall),
+                    "n_variant": n_variant,
+                    "precision_variant": precision_variant,
+                    "recall_variant": recall_variant,
+                    "f1_variant": 2 * precision_variant * recall_variant / (precision_variant + recall_variant),
+                    "truthset_version": truthset_version,
+                    "split": run_type,
+                }
+            )
 
-    run_stats = pd.DataFrame(obs_run_stats_dicts)
+        run_stats = pd.DataFrame(obs_run_stats_dicts)
 
-    all_obs_run_stats[run_type] = run_stats
+        all_obs_run_stats_labeled.append(run_stats)
+
 
 # %% Make another version of the performance barplot where both train and test are shown together.
 
 sns.set_theme(style="whitegrid")
 
-all_obs_run_stats_labeled = []
-for run_type in ["train", "test"]:
-    run_stats_labeled = all_obs_run_stats[run_type].copy()
-    run_stats_labeled["split"] = run_type
-    all_obs_run_stats_labeled.append(run_stats_labeled)
-
 obs_run_stats_labeled = pd.concat(all_obs_run_stats_labeled)
 
 obs_run_stats_labeled_melted = obs_run_stats_labeled[
-    ["split", "run_id", "precision", "recall", "precision_variant", "recall_variant"]
-].melt(id_vars=["split", "run_id"], var_name="metric", value_name="result")
+    ["split", "run_id", "precision", "recall", "precision_variant", "recall_variant", "truthset_version"]
+].melt(id_vars=["split", "run_id", "truthset_version"], var_name="metric", value_name="result")
 
 # Recode split from "train" and "test" to "dev" and "eval".
 obs_run_stats_labeled_melted["split"] = obs_run_stats_labeled_melted["split"].map({"train": "dev", "test": "eval"})
@@ -116,20 +118,17 @@ g = sns.barplot(
     x="metric",
     y="result",
     errorbar="sd",
-    hue="split",
+    hue="truthset_version",
     alpha=0.6,
-    palette={"dev": "#1F77B4", "eval": "#FA621E"},
+    palette={"v1": "#1F77B4", "v1.1": "#FA621E"},
 )
 # Rename the x labels to precision, recall, precision (variant), recall (variant).
 g.set_xticklabels(["Precision", "Recall", "Variant\nprecision", "Variant\nrecall"])
 
-# Remove the legend
-g.get_legend().remove()
-
 g.xaxis.set_label_text("")
 g.yaxis.set_label_text("Proportion")
 g.title.set_text("Observation finding")
-plt.ylim(0.5, 1)
+plt.ylim(0.4, 1)
 
 plt.savefig(f"{OUTPUT_DIR}/observation_finding_performance{model_suffix}.png", bbox_inches="tight")
 
@@ -141,22 +140,25 @@ pd.set_option("display.max_columns", None)
 width = pd.get_option("display.width")
 pd.set_option("display.width", 2000)
 
-for run_type in ["train", "test"]:
-    run_stats = all_obs_run_stats[run_type]
+for truthset_version in TRUTHSET_VERSIONS:
+    for run_type in ["train", "test"]:
+        run_stats = obs_run_stats_labeled.query(f"truthset_version == '{truthset_version}' and split == '{run_type}'")
 
-    run_type_alt = "dev" if run_type == "train" else "eval"
+        run_type_alt = "dev" if run_type == "train" else "eval"
 
-    print(f"-- Observation finding benchmark results ({run_type_alt}; N={run_stats.shape[0]}) --")
-
-    print(run_stats[["n", "precision", "recall", "n_variant", "precision_variant", "recall_variant"]])
-
-    print()
-    print(
-        run_stats[["n", "precision", "recall", "n_variant", "precision_variant", "recall_variant"]].aggregate(
-            ["mean", "std"]
+        print(
+            f"-- Observation finding benchmark results ({run_type_alt}/{truthset_version}; N={run_stats.shape[0]}) --"
         )
-    )
-    print()
+
+        print(run_stats[["n", "precision", "recall", "n_variant", "precision_variant", "recall_variant"]])
+
+        print()
+        print(
+            run_stats[["n", "precision", "recall", "n_variant", "precision_variant", "recall_variant"]].aggregate(
+                ["mean", "std"]
+            )
+        )
+        print()
 
 pd.set_option("display.max_columns", max_columns)
 pd.set_option("display.width", width)
@@ -167,8 +169,13 @@ pd.set_option("display.width", width)
 if not os.path.exists(OUTPUT_DIR):
     os.makedirs(OUTPUT_DIR)
 
-for run_type in ["train", "test"]:
-    run_stats = all_obs_run_stats[run_type]
-    run_stats.to_csv(f"{OUTPUT_DIR}/observation_finding_benchmarks_{run_type}_{MODEL}.tsv", sep="\t", index=False)
+for truthset_version in TRUTHSET_VERSIONS:
+    for run_type in ["train", "test"]:
+        run_stats = obs_run_stats_labeled.query(f"truthset_version == '{truthset_version}' and split == '{run_type}'")
+        run_stats.to_csv(
+            f"{OUTPUT_DIR}/observation_finding_benchmarks_{truthset_version}_{run_type}_{MODEL}.tsv",
+            sep="\t",
+            index=False,
+        )
 
 # %%

--- a/scripts/benchmark/paper_finding/batch_paper_finding.sh
+++ b/scripts/benchmark/paper_finding/batch_paper_finding.sh
@@ -11,29 +11,38 @@ populate_arrays() {
 
 # Check if model parameter is provided
 if [ -z "$1" ]; then
-    echo "Usage: $0 <model> [truthset_version]"
+    echo "Usage: $0 <model> [truthset_version ...]"
     exit 1
 fi
 
 MODEL=$1
-TRUTHSET_VERSION=${2:-v1.1}
+shift
+TRUTHSET_VERSIONS=("$@")
+if [ ${#TRUTHSET_VERSIONS[@]} -eq 0 ]; then
+    TRUTHSET_VERSIONS=(v1 v1.1)
+fi
 JSON_FILE="scripts/benchmark/benchmark_runs.json"
 
-# Populate TRAIN and TEST arrays
-populate_arrays "$MODEL" "$JSON_FILE"
+for TRUTHSET_VERSION in "${TRUTHSET_VERSIONS[@]}"; do
+    echo "Processing for truthset version: $TRUTHSET_VERSION"
+    # Populate TRAIN and TEST arrays
+    populate_arrays "$MODEL" "$JSON_FILE"
 
-# Loop through each element in the TRAIN list
-for run_id in "${TRAIN[@]}"; do
-    echo "### Processing TRAIN run $run_id ###"
-    python scripts/benchmark/paper_finding/manuscript_single_run.py \
-    -s "scripts/benchmark/paper_finding/paper_finding_benchmarks_skipped_pmids.txt" \
-    -m "data/$TRUTHSET_VERSION/papers_train_$TRUTHSET_VERSION.tsv" -p "$run_id"
-done
+    # Loop through each element in the TRAIN list
+    for run_id in "${TRAIN[@]}"; do
+        echo "### Processing TRAIN run $run_id for $TRUTHSET_VERSION ###"
+        python scripts/benchmark/paper_finding/manuscript_single_run.py \
+        -s "scripts/benchmark/paper_finding/paper_finding_benchmarks_skipped_pmids.txt" \
+        -m "data/$TRUTHSET_VERSION/papers_train_$TRUTHSET_VERSION.tsv" -p "$run_id" \
+        --truthset-version "$TRUTHSET_VERSION"
+    done
 
-# Loop through each element in the TEST list
-for run_id in "${TEST[@]}"; do
-    echo "### Processing TEST run $run_id ###"
-    python scripts/benchmark/paper_finding/manuscript_single_run.py \
-    -s "scripts/benchmark/paper_finding/paper_finding_benchmarks_skipped_pmids.txt" \
-    -m "data/$TRUTHSET_VERSION/papers_test_$TRUTHSET_VERSION.tsv" -p "$run_id"
+    # Loop through each element in the TEST list
+    for run_id in "${TEST[@]}"; do
+        echo "### Processing TEST run $run_id for $TRUTHSET_VERSION ###"
+        python scripts/benchmark/paper_finding/manuscript_single_run.py \
+        -s "scripts/benchmark/paper_finding/paper_finding_benchmarks_skipped_pmids.txt" \
+        -m "data/$TRUTHSET_VERSION/papers_test_$TRUTHSET_VERSION.tsv" -p "$run_id" \
+        --truthset-version "$TRUTHSET_VERSION"
+    done
 done

--- a/scripts/benchmark/paper_finding/manuscript_generate_figures.py
+++ b/scripts/benchmark/paper_finding/manuscript_generate_figures.py
@@ -103,6 +103,8 @@ for truthset_version in TRUTHSET_VERSIONS:
 
 # %%
 # set figure size to 3, 3
+sns.set_theme(style="whitegrid")
+
 plt.figure(figsize=(3, 3))
 
 run_stats_labeled = pd.concat(all_run_stats_labeled, ignore_index=True)
@@ -116,7 +118,6 @@ g = sns.barplot(
     x="stat_type",
     y="stat_value",
     errorbar="sd",
-    alpha=0.6,
     hue="truthset_version",
     palette={"v1": "#1F77B4", "v1.1": "#FCA178"},
 )

--- a/scripts/benchmark/paper_finding/manuscript_generate_figures.py
+++ b/scripts/benchmark/paper_finding/manuscript_generate_figures.py
@@ -22,6 +22,11 @@ from scripts.benchmark.utils import get_benchmark_run_ids, load_run
 
 OUTPUT_DIR = ".out/manuscript_paper_finding"
 
+# ensure OUTPUT_DIR exists
+if not os.path.exists(OUTPUT_DIR):
+    os.makedirs(OUTPUT_DIR)
+    
+
 MODEL = "GPT-4-Turbo"  # or "GPT-4o" or "GPT-4o-mini"
 
 TRAIN_RUNS = get_benchmark_run_ids(MODEL, "train")

--- a/scripts/benchmark/paper_finding/manuscript_generate_figures.py
+++ b/scripts/benchmark/paper_finding/manuscript_generate_figures.py
@@ -118,12 +118,13 @@ g = sns.barplot(
     errorbar="sd",
     alpha=0.6,
     hue="truthset_version",
-    palette={"v1": "#1F77B4", "v1.1": "#FA621E"},
+    palette={"v1": "#1F77B4", "v1.1": "#FCA178"},
 )
 g.xaxis.set_label_text("")
 g.yaxis.set_label_text("Proportion")
 g.set_title("Paper selection")
 g.set_xticklabels([x.get_text().capitalize() for x in g.get_xticklabels()])
+g.get_legend().remove()
 plt.ylim(0.4, 1)
 plt.savefig(f"{OUTPUT_DIR}/paper_finding_benchmark_performance{model_name}.png", bbox_inches="tight")
 

--- a/scripts/truthset/error_analysis/error_analysis_summary.py
+++ b/scripts/truthset/error_analysis/error_analysis_summary.py
@@ -227,7 +227,7 @@ for task in ["papers", "observations"]:
         .plot(kind="bar", stacked=True, color=["#FCA178", "#1F77B4"])
     )
     # set the fig size
-    plt.gcf().set_size_inches(4, 4)
+    plt.gcf().set_size_inches(4, 3)
 
     # set xlabel orientation to horizontal
     plt.xticks(rotation=0)
@@ -262,7 +262,7 @@ g = (
     .unstack()
     .plot(kind="bar", stacked=True, color=["#FCA178", "#1F77B4"])
 )
-plt.gcf().set_size_inches(6, 4)
+plt.gcf().set_size_inches(6, 3)
 
 plt.title("Content extraction error analysis")
 plt.ylabel("Count")


### PR DESCRIPTION
This PR supports figure updates for manuscript revision and better instructions for reproducing these figures.

- The biggest set of changes is aimed at simultaneously plotting the benchmark results for comparison against multiple versions of the truth set. This propagates all the way back to how we run those benchmark analyses.
- Additionally, because some figures have been merged, this PR includes a bunch of consistency and format changes to the generated plots.
- Finally I've updated the relevant README with instructions for how to run these new benchmarks.

Tests pass and linters are happy.