### PR TITLE
Filter out header-only sections

### DIFF
--- a/lib/evagg/content/observation.py
+++ b/lib/evagg/content/observation.py
@@ -278,7 +278,22 @@ uninterrupted sequences of whitespace characters.
         for id in table_ids:
             table_texts.append("\n\n".join([sec.text for sec in table_sections if sec.id == id]))
 
-        return full_text, table_texts
+        # Filter out header-only table segments that don't contain actual data
+        filtered_table_texts = []
+        for table_text in table_texts:
+            lines = [line.strip() for line in table_text.split('\n') if line.strip()]
+            
+            # Filter criteria to identify header-only segments
+            has_sufficient_lines = len(lines) > 2
+            has_sufficient_length = len(table_text) > 100
+            
+            # Only include segments that look like actual tables with data
+            if has_sufficient_lines and has_sufficient_length:
+                filtered_table_texts.append(table_text)
+            else:
+                logger.debug(f"Filtered out header-only table segment from {paper.id}: {table_text[:50]}...")
+        
+        return full_text, filtered_table_texts
 
     def _get_text_mentioning_variant(self, paper: Paper, variant_descriptions: Sequence[str], allow_empty: bool) -> str:
         sections = get_sections(paper.props["fulltext_xml"])


### PR DESCRIPTION
For example, https://www.ncbi.nlm.nih.gov/research/bionlp/RESTful/pmcoa.cgi/BioC_xml/30681346/ascii has "tables" like these:

```xml
<passage>
<infon key="file"/>
<infon key="id">T3</infon>
<infon key="section_type">TABLE</infon>
<infon key="type">table_caption</infon>
<offset>9679</offset>
<text>Genetic, Experimental, and Overall Classifications for Genes Curated for Syndromes Including LVH</text>
</passage>
```

That triggers LLMs to hallucinate additional content, e.g. by repeating the example variants from the prompt.