### PR TITLE
Add an interface for finding variants

### DIFF
--- a/lib/config/benchmark_observation.yaml
+++ b/lib/config/benchmark_observation.yaml
@@ -42,6 +42,9 @@ extractor:
       di_factory: lib/config/objects/variant_factory_cache.yaml
     variant_comparator:
       di_factory: lib.evagg.content.HGVSVariantComparator
+    variant_finder:
+      di_factory: lib.evagg.content.LLMVariantFinder
+      llm_client: "{{llm_client}}"
 writer:
   di_factory: lib.evagg.TableOutputWriter
   tsv_name: observation_benchmark

--- a/lib/config/evagg_pipeline.yaml
+++ b/lib/config/evagg_pipeline.yaml
@@ -41,6 +41,9 @@ extractor:
       di_factory: lib/config/objects/variant_factory_cache.yaml
     variant_comparator: 
       di_factory: lib.evagg.content.HGVSVariantComparator
+    variant_finder:
+      di_factory: lib.evagg.content.LLMVariantFinder
+      llm_client: "{{llm_client}}"
 writer:
   di_factory: lib.evagg.TableOutputWriter
   tsv_name: pipeline_benchmark

--- a/lib/config/evagg_pipeline_example.yaml
+++ b/lib/config/evagg_pipeline_example.yaml
@@ -45,6 +45,9 @@ extractor:
       # di_factory: lib/config/objects/variant_factory_cache.yaml
     variant_comparator: 
       di_factory: lib.evagg.content.HGVSVariantComparator
+    variant_finder:
+      di_factory: lib.evagg.content.LLMVariantFinder
+      llm_client: "{{llm_client}}"
 writer:
   di_factory: lib.evagg.TableOutputWriter
   tsv_name: pipeline_benchmark

--- a/lib/evagg/content/__init__.py
+++ b/lib/evagg/content/__init__.py
@@ -1,4 +1,5 @@
-from .interfaces import ICompareVariants, IFindObservations, Observation, TextSection
+from .interfaces import ICompareVariants, IFindObservations, IFindVariants, Observation, TextSection
+from .llm_variant_finder import LLMVariantFinder
 from .observation import ObservationFinder
 from .prompt_based import PromptBasedContentExtractor
 from .prompt_based_cache import PromptBasedContentExtractorCached
@@ -11,11 +12,13 @@ __all__ = [
     # Interfaces.
     "ICompareVariants",
     "IFindObservations",
+    "IFindVariants",
     "Observation",
     "TextSection",
     # Mention.
     "HGVSVariantFactory",
     "HGVSVariantComparator",
     # Observation.
+    "LLMVariantFinder",
     "ObservationFinder",
 ]

--- a/lib/evagg/content/interfaces.py
+++ b/lib/evagg/content/interfaces.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List, Protocol, Sequence, Set
+from typing import Any, Dict, List, Protocol, Sequence, Set
 
 from lib.evagg.types import HGVSVariant, Paper
 
@@ -41,6 +41,18 @@ class Observation:
     patient_descriptions: List[str]
     texts: List[TextSection]
     paper_id: str
+
+
+class IFindVariants(Protocol):
+    async def find_variant_descriptions(
+        self, full_text: str, focus_texts: Sequence[str] | None, gene_symbol: str, metadata: Dict[str, Any]
+    ) -> Sequence[str]:
+        """Identify the genetic variants relevant to the gene_symbol described in the full text of the paper.
+
+        Returned variants will be _as described_ in the source text. Downstream manipulations to make them
+        HGVS-compliant may be required.
+        """
+        ...  # pragma: no cover
 
 
 class IFindObservations(Protocol):

--- a/lib/evagg/content/llm_variant_finder.py
+++ b/lib/evagg/content/llm_variant_finder.py
@@ -1,0 +1,106 @@
+import asyncio
+import logging
+from typing import Any, Dict, Sequence
+
+from lib.evagg.llm import IPromptClient
+
+from .interfaces import IFindVariants
+from .observation import _get_prompt_file_path, run_json_prompt
+
+logger = logging.getLogger(__name__)
+
+
+class LLMVariantFinder(IFindVariants):
+    _SYSTEM_PROMPT = """
+You are an intelligent assistant to a genetic analyst. Their task is to identify the genetic variant or variants that
+are causing a patient's disease. One approach they use to solve this problem is to seek out evidence from the academic
+literature that supports (or refutes) the potential causal role that a given variant is playing in a patient's disease.
+
+As part of that process, you will assist the analyst in identifying observations of genetic variation in human
+subjects/patients.
+
+All of your responses should be provided in the form of a JSON object. These responses should never include long,
+uninterrupted sequences of whitespace characters.
+"""
+
+    def __init__(self, llm_client: IPromptClient) -> None:
+        self._llm_client = llm_client
+
+    async def _run_json_prompt(
+        self, prompt_filepath: str, params: Dict[str, str], prompt_settings: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        return await run_json_prompt(self._llm_client, prompt_filepath, params, prompt_settings, self._SYSTEM_PROMPT)
+
+    async def find_variant_descriptions(
+        self, full_text: str, focus_texts: Sequence[str] | None, gene_symbol: str, metadata: Dict[str, Any]
+    ) -> Sequence[str]:
+        """Identify the genetic variants relevant to the gene_symbol described in the full text of the paper.
+
+        Returned variants will be _as described_ in the source text. Downstream manipulations to make them
+        HGVS-compliant may be required.
+        """
+        # Create prompts to find all the unique variants mentioned in the full text and focus texts.
+        prompt_runs = [
+            self._run_json_prompt(
+                prompt_filepath=_get_prompt_file_path("find_variants"),
+                params={"text": text, "gene_symbol": gene_symbol},
+                prompt_settings={"prompt_tag": "observation__find_variants", "prompt_metadata": metadata},
+            )
+            for text in ([full_text] if full_text else []) + list(focus_texts or [])
+        ]
+
+        # Run prompts in parallel.
+        responses = await asyncio.gather(*prompt_runs)
+
+        # Often, the gene-symbol is provided as a prefix to the variant, remove it.
+        # Note: we do additional similar checks later, but it's useful to do it now to reduce redundancy.
+        def _strip_gene_symbol(x: str) -> str:
+            # If x starts with gene_symbol, remove that and any subsequent colon.
+            if x.startswith(gene_symbol):
+                return x[len(gene_symbol) :].lstrip(":")
+            return x
+
+        candidates = list({_strip_gene_symbol(v) for r in responses for v in r.get("variants", []) if v != "unknown"})
+
+        # Seems like this should be unnecessary, but remove the example variants from the list of candidates.
+        example_variant_subs = [
+            "1234A>T",
+            "2345del",
+            "K34T",
+            "rs123456789",
+            "A55T",
+            "Ala55Lys",
+            "K412T",
+            "Ser195Gly",
+            "T65I",
+            "1234G>T",
+            "4321A>G",
+            "1234567A>T",
+        ]
+
+        if any(ex in ca for ex in example_variant_subs for ca in candidates):
+            candidates_from_examples = [ca for ca in candidates if any(ex in ca for ex in example_variant_subs)]
+            logger.warning(
+                f"Removing example variants found in candidates for {gene_symbol}: {candidates_from_examples}"
+            )
+            candidates = [ca for ca in candidates if ca not in candidates_from_examples]
+
+        # If the variant is reported with both coding and protein-level
+        # descriptions, split these into two with another prompt.
+        split_prompt_runs = []
+        for i in reversed(range(len(candidates))):
+            if "p." in candidates[i] and "c." in candidates[i]:
+                split_prompt_runs.append(
+                    self._run_json_prompt(
+                        prompt_filepath=_get_prompt_file_path("split_variants"),
+                        params={"variant_list": f'"{candidates[i]}"'},  # Encase in double-quotes for bulk calling.
+                        prompt_settings={"prompt_tag": "observation__split_variants", "prompt_metadata": metadata},
+                    )
+                )
+                del candidates[i]
+        # Run split prompts in parallel.
+        split_responses = await asyncio.gather(*split_prompt_runs)
+        # Add the split variants back in to the candidates list.
+        candidates.extend(v for r in split_responses for v in r.get("variants", []))
+
+        return candidates


### PR DESCRIPTION
This is a functional no-op, but will make it possible in follow-up commits to toggle between different implementations, e.g. NER instead of LLM.

Not sure what the unrelated formatting changes are about -- this is `black` with a line length of 120...