### PR TITLE
Add cache dir utility

### DIFF
--- a/lib/config/benchmark_observation.yaml
+++ b/lib/config/benchmark_observation.yaml
@@ -8,6 +8,9 @@ log:
   level: INFO
   to_file: true
 
+cache_dir_manager:
+  di_factory: lib.evagg.utils.CacheDirectoryManager
+
 # Imported objects.
 llm_client:
   di_factory: lib/config/objects/llm.yaml

--- a/lib/config/evagg_pipeline.yaml
+++ b/lib/config/evagg_pipeline.yaml
@@ -7,6 +7,9 @@ log:
   level: INFO
   to_file: true
 
+cache_dir_manager:
+  di_factory: lib.evagg.utils.CacheDirectoryManager
+
 # Imported objects.
 llm_client:
   di_factory: lib/config/objects/llm.yaml

--- a/lib/config/evagg_pipeline_example.yaml
+++ b/lib/config/evagg_pipeline_example.yaml
@@ -8,6 +8,9 @@ log:
   level: INFO
   to_file: true
 
+cache_dir_manager:
+  di_factory: lib.evagg.utils.CacheDirectoryManager
+
 # Imported objects.
 llm_client:
   di_factory: lib/config/objects/llm.yaml

--- a/lib/config/objects/refseq.yaml
+++ b/lib/config/objects/refseq.yaml
@@ -4,3 +4,4 @@ web_client:
   settings:
     status_code_translator:
       di_factory: lib.evagg.ref.ncbi.get_ncbi_response_translator
+cache_dir_manager: "{{cache_dir_manager}}"

--- a/lib/config/objects/refseq_cache.yaml
+++ b/lib/config/objects/refseq_cache.yaml
@@ -4,3 +4,4 @@ web_client:
   web_settings:
     status_code_translator:
       di_factory: lib.evagg.ref.ncbi.get_ncbi_response_translator
+cache_dir_manager: "{{cache_dir_manager}}"

--- a/lib/evagg/ref/refseq.py
+++ b/lib/evagg/ref/refseq.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional
 import requests
 
 from lib.evagg.utils import IWebContentClient
+from lib.evagg.utils.cache_dirs import CacheDirectoryManager
 
 from .interfaces import IRefSeqLookupClient
 from .ncbi import NcbiClientBase
@@ -16,18 +17,17 @@ logger = logging.getLogger(__name__)
 
 
 class BaseLookupClient(NcbiClientBase, IRefSeqLookupClient):
-    _DEFAULT_REFERENCE_DIR = ".ref"
     _ref: Dict[str, Dict[str, str]]
     _lazy_initialized: bool
 
     def __init__(
         self,
         web_client: IWebContentClient,
+        cache_dir_manager: CacheDirectoryManager,
         settings: Optional[Dict[str, str]] = None,
-        reference_dir: str = _DEFAULT_REFERENCE_DIR,
     ) -> None:
         # Lazy initialize so the constructor is fast.
-        self._reference_dir = reference_dir
+        self._reference_dir = cache_dir_manager.get_cache_dir("ref")
         self._lazy_initialized = False
         self._ref = {}
 

--- a/lib/evagg/utils/__init__.py
+++ b/lib/evagg/utils/__init__.py
@@ -1,10 +1,13 @@
 """Package for utilities."""
 
+from .cache_dirs import CacheDirectoryManager
 from .logging import init_logger
 from .settings import get_azure_credential, get_dotenv_settings, get_env_settings
 from .web import CosmosCachingWebClient, IWebContentClient, RequestsWebContentClient
 
 __all__ = [
+    # Cache.
+    "CacheDirectoryManager",
     # Settings.
     "get_azure_credential",
     "get_dotenv_settings",

--- a/lib/evagg/utils/cache_dirs.py
+++ b/lib/evagg/utils/cache_dirs.py
@@ -1,0 +1,31 @@
+"""Cache directory management utilities."""
+import os
+from typing import Optional
+
+
+class CacheDirectoryManager:
+    """Manages cache directories for various components."""
+    
+    _DEFAULT_CACHE_DIR = ".cache"
+    
+    def __init__(self, cache_dir: Optional[str] = None):
+        """Initialize cache directory manager.
+        
+        Args:
+            cache_dir: Root cache directory. Defaults to .cache
+        """
+        self._cache_dir = cache_dir or self._DEFAULT_CACHE_DIR
+    
+    def get_cache_dir(self, subdirectory: str) -> str:
+        """Get or create a cache subdirectory.
+        
+        Args:
+            subdirectory: Name of the subdirectory within cache
+            
+        Returns:
+            Full path to the cache subdirectory
+        """
+        cache_path = os.path.join(self._cache_dir, subdirectory)
+        if not os.path.exists(cache_path):
+            os.makedirs(cache_path, exist_ok=True)
+        return cache_path


### PR DESCRIPTION
A a small utility class to manage directories for file caches that can be used across pipeline runs.

So far it's only used for the ref seq lookups, but in the future it can e.g. be used to store NER model weights or similar.